### PR TITLE
Remove early size check requirement in `OffByTwo.kt`

### DIFF
--- a/paparazzi/src/main/java/app/cash/paparazzi/internal/OffByTwo.kt
+++ b/paparazzi/src/main/java/app/cash/paparazzi/internal/OffByTwo.kt
@@ -8,8 +8,6 @@ import kotlin.math.max
 
 internal object OffByTwo : Differ {
   override fun compare(expected: BufferedImage, actual: BufferedImage): DiffResult {
-    check(expected.width == actual.width && expected.height == actual.height) { "Images are different sizes" }
-
     val expectedWidth = expected.width
     val expectedHeight = expected.height
 


### PR DESCRIPTION
This will make `OffByTwo.kt` behaves identical to the original `PixelPerfect` differ. But most importantly, it will restore the initial behavior of `ImageUtils.assertImageSimilar()` itself, checking for differences in size and correctly producing the expected delta (and actual) images in case of a size mismatch.

Relates to #1716